### PR TITLE
Use milk rm if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,6 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-source :rubygems
+source "https://rubygems.org"
 
 gemspec

--- a/gem-milkode.gemspec
+++ b/gem-milkode.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("lib/**/*.rb")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("milkode")
+  spec.add_runtime_dependency("milkode", ">=1.8.4")
   spec.add_development_dependency("bundler")
 end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -54,6 +54,6 @@ if current_version == sorted_installed_versions.last
 
   Gem.post_uninstall do |uninstaller|
     ensure_init.call
-    system(*(milk_command_line + ["remove", uninstaller.spec.gem_dir]))
+    system(*(milk_command_line + ["rm", uninstaller.spec.gem_dir]))
   end
 end


### PR DESCRIPTION
When uninstalling gems, milkode warns that:

> [warning] 'milk remove' is obsolete. Please use 'milk rm'.

This patch makes gem-milkode use `milk rm` if it's available.
Could you consider it?

Thanks.
